### PR TITLE
Fix nested hook calls

### DIFF
--- a/pyhooks/hooks.py
+++ b/pyhooks/hooks.py
@@ -21,9 +21,11 @@ class Hook(object):
         """Run the hooks and the hooked method, respecting the location of
         hooks
         """
+        saved_instance = self.instance
         self.run_tagged_methods(self.name, PRECALL_TAG, *args, **kwargs)
-        return_value = self.method(self.instance, *args, **kwargs)
+        return_value = self.method(saved_instance, *args, **kwargs)
         self.run_tagged_methods(self.name, POSTCALL_TAG, *args, **kwargs)
+        self.instance = saved_instance
         return return_value
 
     def __get__(self, instance, owner):


### PR DESCRIPTION
Fixed a bug where hooked methods would be called with the wrong object if another hooked method would be called while the hook was running.